### PR TITLE
Update DscAlarm.yaml

### DIFF
--- a/DscAlarm.yaml
+++ b/DscAlarm.yaml
@@ -110,10 +110,11 @@ api:
   #discovery_prefix: "homeassistant"
   #topic_prefix: $name
  
+safe_mode:
 
 ota:
+   platform: esphome
    password: !secret ota_password
-   safe_mode: True
    on_begin:
        switch.turn_off: connection_status_switch   
    


### PR DESCRIPTION
fix: ota platform
doesn't compile due to required platform key is missing